### PR TITLE
Document local Prisma env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"


### PR DESCRIPTION
## Summary

Adds an `.env.example` file for local development.

## Why

When running the app from source, Prisma requires `DATABASE_URL`. Without a `.env` file, local setup fails with:

`Environment variable not found: DATABASE_URL`

This example points Prisma at the local SQLite database used by the project.

## Suggested README follow-up

The developer setup docs could also mention:

```bash
cp .env.example .env
npx prisma db push

```

before running:

```bash
npm run dev
```