### PR TITLE
Fix electron map tiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/src/components/scans/MiniMap.tsx
+++ b/src/components/scans/MiniMap.tsx
@@ -70,8 +70,7 @@ export function MiniMap({ lat, lng, rank, onEnlarge }: MiniMapProps) {
                 className="w-full h-full z-0"
             >
                 <TileLayer
-                    url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-                />
+url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"                />
                 <Marker position={[lat, lng]} icon={createNumberedMarker(rank, 24)} />
             </MapContainer>
 


### PR DESCRIPTION
## Summary

Fixes map tile rendering in the Electron desktop app.

## Why

In the native app, Leaflet controls and rank markers rendered correctly, but the map background stayed grey because map tiles were not loading.

## Changes

- Removed `crossOrigin="anonymous"` from the main Leaflet `TileLayer`
- Switched [MiniMap](cci:1://file:///Users/johnstott/Google-Maps-SERP/src/components/scans/MiniMap.tsx:56:0-91:1) tiles from CARTO to OpenStreetMap to match the main map tile source

## Testing

Verified locally in Electron dev mode:

- Ran `npm run electron:dev`
- Completed a scan successfully
- Opened the scan report in the Electron app
- Confirmed the map background tiles render correctly
- Confirmed rank markers still render correctly